### PR TITLE
ColorInfo: Change copy to mention dark gray 900

### DIFF
--- a/src/components/color-info/card.js
+++ b/src/components/color-info/card.js
@@ -20,7 +20,7 @@ export default function Card( props ) {
 	const { color, name, subtitle } = props;
 	const contrastScore = getContrastScore( color );
 	const isLightText = shouldUseLightText( color );
-	const textLabel = isLightText ? 'light' : 'dark';
+	const textLabel = isLightText ? 'white' : 'Dark Gray 900';
 
 	return (
 		<Box className={ classnames() }>


### PR DESCRIPTION
## ColorInfo: Change copy to mention dark gray 900

![Screen Shot 2019-10-09 at 6 46 30 PM](https://user-images.githubusercontent.com/2322354/66526055-66765a00-eac5-11e9-96f9-74bd9bcd7d36.png)

This update changes the text label in the ColorInfo component to recommend
using Dark Gray 900 instead of just "dark" as the text color to use against
a certain color.

👉 Check it out: https://deploy-preview-6--wp-design-guidelines.netlify.com/foundations/colors/

Resolves: https://github.com/ItsJonQ/wordpress-design-guidelines/issues/4