### PR TITLE
Update anchor links in (ja) color page

### DIFF
--- a/content/ja/foundations/colors.mdx
+++ b/content/ja/foundations/colors.mdx
@@ -7,13 +7,13 @@ import { CalloutCardIdentity, ColorSet, ColorInfo, TopLink } from 'components';
 
 # カラー
 
-色はブランド認知の為の重要な側面の1つです。正しい色相 (色) を使用する為に確認を行うことが不可欠です。
+色はブランド認知の為の重要な側面の 1 つです。正しい色相 (色) を使用する為に確認を行うことが不可欠です。
 
-カラーはブルー、グレー、補助色相の3つのグループに分かれています:
+カラーはブルー、グレー、補助色相の 3 つのグループに分かれています:
 
--   [Blue](#blue)
--   [Gray](#gray)
--   [Auxiliary](#auxiliary)
+-   [ブルー](#ブルー)
+-   [グレー](#グレー)
+-   [補助色相](#補助色相)
 
 最もよく知られているカラーは、ブルーとグレーです。補助色相はさまざまな理由で使用でき、いくつかの色合い (白を加えたもの) 、色調 (別の色相との混合) 、陰影 (黒を加えたもの) があります。
 
@@ -39,7 +39,7 @@ import { CalloutCardIdentity, ColorSet, ColorInfo, TopLink } from 'components';
 
 -   [Adobe Swatches (.ase)](https://cldup.com/41wt38Q-cI.ase) ([@antpb](https://profiles.wordpress.org/antpb/) さん、ありがとうございます。)
 -   [Adobe Illustrator (.ai)](https://cldup.com/DG7vCr8ERF.ai) ([@antpb](https://profiles.wordpress.org/antpb/) さん、ありがとうございます。)
--   カラー要素を含むSketchファイル (貢献をお待ちしています。Slackで [@hugobaeta](https://profiles.wordpress.org/hugobaeta/) さんにご連絡ください。)
+-   カラー要素を含む Sketch ファイル (貢献をお待ちしています。Slack で [@hugobaeta](https://profiles.wordpress.org/hugobaeta/) さんにご連絡ください。)
 
 ## リソース
 

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -11,8 +11,9 @@ const scrollTo = ( id ) => () => {
 	return false;
 };
 
-export const onRouteUpdate = ( { location: { hash } } ) => {
+export const onRouteUpdate = ( props ) => {
+	const { location: { hash } } = props;
 	if ( hash ) {
-		window.setTimeout( scrollTo( hash ), 10 );
+		window.setTimeout( scrollTo( decodeURIComponent( hash ) ), 10 );
 	}
 };

--- a/src/components/callout-card-identity.js
+++ b/src/components/callout-card-identity.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -9,16 +10,32 @@ import React from 'react';
 import { useAppContext } from './app-provider';
 import { Box, CalloutCard, Link, Text } from './index';
 
+// TODO: REFACTOR TO GLOBAL LABELS
+const labels = {
+	en: {
+		message: 'Are you also looking for the',
+		link: 'official logos',
+	},
+};
+// TODO: REFACTOR OR USE i18n TRANSLATION METHOD
+const t = ( lang = 'en', prop ) => {
+	const fallback = get( labels, `en.${ prop }` );
+	return get( labels, `${ lang }.${ prop }`, fallback );
+};
+
 export default function CalloutCardIdentity() {
-	const { baseLangUrl } = useAppContext();
+	const { baseLangUrl, lang } = useAppContext();
 	const url = `/${ baseLangUrl }/foundations/identity/`;
+
+	const message = t( lang, 'message' );
+	const link = t( lang, 'link' );
 
 	return (
 		<Box my={ 4 }>
 			<CalloutCard>
 				<Text>
-					Are you also looking for the{ ' ' }
-					<Link to={ url }>official logos</Link>?
+					{ message }{ ' ' }
+					<Link to={ url }>{ link }</Link>?
 				</Text>
 			</CalloutCard>
 		</Box>

--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -19,7 +19,9 @@ export function useAnchorLinks() {
 				return;
 			}
 
-			window.history.pushState( {}, null, target.href );
+			const targetHref = decodeURIComponent( target.href );
+
+			window.history.pushState( {}, null, targetHref );
 			event.preventDefault();
 
 			const targetNode = document.querySelector( href );
@@ -33,9 +35,10 @@ export function useAnchorLinks() {
 
 		const handleOnClickAnchor = ( event ) => {
 			const { currentTarget: target } = event;
+			const targetHref = decodeURIComponent( target.href );
 			event.preventDefault();
-			window.history.pushState( {}, null, target.href );
-			copyToClipboard( target.href );
+			window.history.pushState( {}, null, targetHref );
+			copyToClipboard( decodeURIComponent( targetHref ) );
 		};
 
 		Array.from( linkNodes ).forEach( ( node ) => {

--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -13,7 +13,7 @@ export function useAnchorLinks() {
 
 		const handleOnClickLink = ( event ) => {
 			const { currentTarget: target } = event;
-			const href = target.getAttribute( 'href' );
+			const href = decodeURIComponent( target.getAttribute( 'href' ) );
 
 			if ( href.indexOf( '#' ) !== 0 ) {
 				return;


### PR DESCRIPTION
## Update anchor links in (ja) color page

![Screen Shot 2019-11-08 at 9 56 01 AM](https://user-images.githubusercontent.com/2322354/68486533-3f6b8f00-020f-11ea-84da-0527f2ce547f.png)


This update changes the anchor links on the JA color page from English to
Japanese.

In order to do this, I needed to update how the JavaScript code handle anchor
click events.

I've also added very basic translation features to the CalloutCard component.